### PR TITLE
Update compose.yaml to use Named Volumes

### DIFF
--- a/.github/deployment/self-host/compose.yaml
+++ b/.github/deployment/self-host/compose.yaml
@@ -14,14 +14,17 @@ services:
         condition: service_healthy
     volumes:
       # custom configurations
-      - ~/.affine/self-host/config:/root/.affine/config
+      #- ~/.affine/self-host/config:/root/.affine/config
+      - affine_config:/root/.affine/config
       # blob storage
-      - ~/.affine/self-host/storage:/root/.affine/storage
+      #- ~/.affine/self-host/storage:/root/.affine/storage
+      - affine_storage:/root/.affine/storage
     logging:
       driver: 'json-file'
       options:
         max-size: '1000m'
     restart: unless-stopped
+    env_file: stack.env
     environment:
       - NODE_OPTIONS="--import=./scripts/register.js"
       - AFFINE_CONFIG_PATH=/root/.affine/config
@@ -38,7 +41,8 @@ services:
     container_name: affine_redis
     restart: unless-stopped
     volumes:
-      - ~/.affine/self-host/redis:/data
+    #  - ~/.affine/self-host/redis:/data
+      - affine-redis_data:/data
     healthcheck:
       test: ['CMD', 'redis-cli', '--raw', 'incr', 'ping']
       interval: 10s
@@ -49,7 +53,8 @@ services:
     container_name: affine_postgres
     restart: unless-stopped
     volumes:
-      - ~/.affine/self-host/postgres:/var/lib/postgresql/data
+    #  - ~/.affine/self-host/postgres:/var/lib/postgresql/data
+      - affine-postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U affine']
       interval: 10s
@@ -60,3 +65,13 @@ services:
       POSTGRES_PASSWORD: affine
       POSTGRES_DB: affine
       PGDATA: /var/lib/postgresql/data/pgdata
+
+volumes:
+  affine-postgres_data:
+     driver: local
+  affine-redis_data:
+     driver: local
+  affine_config:
+     driver: local
+  affine_storage:
+     driver: local


### PR DESCRIPTION
Changes to enable managed Docker Environments to store all of AFFiNE's data and configuration into Named Volumes that can be managed by a service such as Portainer.